### PR TITLE
Modify path variables so that an alternative auxiliary location can be used

### DIFF
--- a/Global21cmLSTM/emulator_21cmGEM.py
+++ b/Global21cmLSTM/emulator_21cmGEM.py
@@ -7,7 +7,7 @@ from tensorflow.keras.layers import LSTM, Dense
 from Global21cmLSTM import __path__
 import Global21cmLSTM.preprocess_21cmGEM as pp
 
-PATH = f"{os.environ.get('HOME')}/.Global21cmLSTM/"
+PATH = f"{os.environ.get('AUX_DIR', os.environ.get('HOME'))}/.Global21cmLSTM/"
 z_list = np.linspace(5, 50, 451) # list of redshifts for 21cmGEM signals; equiv to np.arange(5, 50.1, 0.1)
 vr = 1420.4057517667  # rest frequency of 21 cm line in MHz
 with h5py.File(PATH + 'dataset_21cmGEM.h5', "r") as f:

--- a/Global21cmLSTM/emulator_ARES.py
+++ b/Global21cmLSTM/emulator_ARES.py
@@ -7,7 +7,7 @@ from tensorflow.keras.layers import LSTM, Dense
 from Global21cmLSTM import __path__
 import Global21cmLSTM.preprocess_ARES as pp
 
-PATH = f"{os.environ.get('HOME')}/.Global21cmLSTM/"
+PATH = f"{os.environ.get('AUX_DIR', os.environ.get('HOME'))}/.Global21cmLSTM/"
 z_list = np.linspace(5.1, 49.9, 449) # list of redshifts for ARES signals; equiv to np.arange(5.1, 50, 0.1)
 vr = 1420.4057517667  # rest frequency of 21 cm line in MHz
 with h5py.File(PATH + 'dataset_ARES.h5', "r") as f:

--- a/Global21cmLSTM/eval_21cmGEM.py
+++ b/Global21cmLSTM/eval_21cmGEM.py
@@ -6,7 +6,7 @@ from tensorflow import keras
 from tensorflow.keras import backend as K
 from Global21cmLSTM import __path__
 
-PATH = f"{os.environ.get('HOME')}/.Global21cmLSTM/"
+PATH = f"{os.environ.get('AUX_DIR', os.environ.get('HOME'))}/.Global21cmLSTM/"
 
 class evaluate_21cmGEM():
     def __init__(self, **kwargs):

--- a/Global21cmLSTM/eval_ARES.py
+++ b/Global21cmLSTM/eval_ARES.py
@@ -6,7 +6,7 @@ from tensorflow import keras
 from tensorflow.keras import backend as K
 from Global21cmLSTM import __path__
 
-PATH = f"{os.environ.get('HOME')}/.Global21cmLSTM/"
+PATH = f"{os.environ.get('AUX_DIR', os.environ.get('HOME'))}/.Global21cmLSTM/"
 
 class evaluate_ARES():
     def __init__(self, **kwargs):

--- a/Global21cmLSTM/preprocess_21cmGEM.py
+++ b/Global21cmLSTM/preprocess_21cmGEM.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os
 
-PATH = f"{os.environ.get('HOME')}/.Global21cmLSTM/"
+PATH = f"{os.environ.get('AUX_DIR', os.environ.get('HOME'))}/.Global21cmLSTM/"
 
 def preproc_params(unproc_params: np.ndarray, train_params: np.ndarray) -> np.ndarray:
     """

--- a/Global21cmLSTM/preprocess_ARES.py
+++ b/Global21cmLSTM/preprocess_ARES.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os
 
-PATH = f"{os.environ.get('HOME')}/.Global21cmLSTM/"
+PATH = f"{os.environ.get('AUX_DIR', os.environ.get('HOME'))}/.Global21cmLSTM/"
 
 def preproc_params(unproc_params: np.ndarray, train_params: np.ndarray) -> np.ndarray:
     """

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,12 @@ setup(
     ],
 )
 
-# the below code creates a hidden folder in $HOME to store needed auxiliary H5 and txt files (i.e., data sets, trained models, training set min and max values)
-# and copies/downloads those files to the folder
-# the location of this folder can be changed here if the user's $HOME has storage limitations, but note that if the location of this folder is changed here
-# then the specified PATH must be updated in the emulator.py, preprocess.py, and eval.py scripts for the respective model/data
-BASE_PATH = f"{os.environ.get('HOME')}/.Global21cmLSTM/"
+# the below code creates a hidden folder in $HOME to store needed auxiliary H5 and txt files 
+# (i.e., data sets, trained models, training set min and max values) and copies/downloads those files to the folder.
+# The location of this folder can be changed here if the user's $HOME has storage limitations by setting the 
+# environment variable AUX_DIR to an alternative location. Note: AUX_DIR will need to be set each time the 
+# package is used. 
+BASE_PATH = f"{os.environ.get('AUX_DIR', os.environ.get('HOME'))}/.Global21cmLSTM/"
 MODELS_INSTALL_PATH = os.path.dirname(os.path.realpath(__file__))+'/Global21cmLSTM/models/'
 emulator_files_list = ['emulator_21cmGEM.h5', 'emulator_ARES.h5', 'train_maxs_21cmGEM.txt',\
                        'train_mins_21cmGEM.txt', 'train_maxs_ARES.txt', 'train_mins_ARES.txt']


### PR DESCRIPTION
This PR is a hotfix. Going forward, I would suggest that these path variables be integrated into the API. Additionally, I would suggest that you do not download the data in the `setup.py` file. Instead, I would create a function a user can call to do this.

In this PR I made the following changes:
* Modified the `BASE_PATH` and `PATH` variables used across various scripts. Specifically, I make these variables use a new environment variable called `AUX_DIR` (for auxiliary directory) that specifies where the user wants items to be downloaded or retrieved from. If this `AUX_DIR` environment variable is not specified, then `HOME` will be used.