### PR TITLE
Add Apptainer definition file

### DIFF
--- a/21cmLSTM.def
+++ b/21cmLSTM.def
@@ -1,0 +1,22 @@
+Bootstrap: docker
+From: nvcr.io/nvidia/tensorflow:23.12-tf2-py3
+
+%post
+
+	# install matplotlib
+	pip install matplotlib
+
+	# create environment variable and directory used to store auxiliary files
+	export AUX_DIR=/21cmLSTM_AUX_DIR
+	mkdir -p $AUX_DIR
+	
+	# install 21cmLSTM via pip
+	cd / 
+	git clone https://github.com/jdorigojones/21cmLSTM.git
+	cd 21cmLSTM
+	python -m pip install .
+
+%environment
+
+	# export AUX_DIR so it will automatically be set in the container
+	export AUX_DIR=/21cmLSTM_AUX_DIR

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ cd 21cmLSTM
 python -m pip install .
 ```
 
+## Apptainer container
+
+For ease of use and reproducibility, we also include a definition file for an [Apptainer](https://apptainer.org/) 
+container build. To build the container on a system with Apptainer, execute the following. 
+
+```
+apptainer build --fix-perms --fakeroot --nv 21cmLSTM.sif 21cmLSTM.def
+```
+
+Once the container has been built, you can interact with it using Apptainer commands. For example, you can run 
+the container interactively as follows. 
+
+```
+apptainer shell --nv ./21cmLSTM.sif
+```
+
 # Contributions
 Authors: Johnny Dorigo Jones and Shah Bahauddin
 


### PR DESCRIPTION
In this PR I modify `README.md` to include instructions for the Apptainer container build. Additionally, I add `21cmLSTM.def`, a definition file for a 21cmLSTM compatible container. 